### PR TITLE
fix(css): use more narrow scope of selectors

### DIFF
--- a/css/mcal.css
+++ b/css/mcal.css
@@ -3,13 +3,13 @@
  * If you wish to create a custom style, please edit the styleCustom.css file
  */
 
-#calendar-table {
+.module.calendar_monthly #calendar-table {
 	padding: 5px;
 	display: table;
 	width: 100%;
 }
 
-#calendar-th {
+.module.calendar_monthly #calendar-th {
 	font-weight: bold;
 	text-align: center;
 	font-size: 1.4em;
@@ -17,32 +17,32 @@
 	border-bottom: 1px solid #cccccc;
 }
 
-.calendar-header-day {
+.module.calendar_monthly .calendar-header-day {
 	text-align: center;
 	color: #cccccc;
 	margin: 2px 0px;
 	padding-top: 7px;
 }
 
-.calendar-day {
+.module.calendar_monthly .calendar-day {
 	text-align: center;
 	width: 14.2%;
 }
 
-.monthPrev {
+.module.calendar_monthly .monthPrev {
 	color: #444444;
 }
 
-.monthNext {
+.module.calendar_monthly .monthNext {
 	color: #444444;
 }
 
-.square-content .today {
+.module.calendar_monthly .square-content .today {
 	color: #ffffff;
 	font-weight: bold;
 }
 
-.footer {
+.module.calendar_monthly .footer {
 	text-align: center;
 	font-size: 0.9em;
 	line-height: 1.2em;

--- a/css/themes/block.css
+++ b/css/themes/block.css
@@ -1,26 +1,26 @@
 /* Block styling */
 
-.square-box {
+.module.calendar_monthly .square-box {
 	position: relative;
 	width: 50%;
 	overflow: hidden;
 	margin: 0px auto;
 }
 
-.square-box:before {
+.module.calendar_monthly .square-box:before {
 	content: "";
 	display: block;
 	padding-top: 20%;
 }
 
-.square-content {
+.module.calendar_monthly .square-content {
 	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
 }
 
-.square-content .today {
+.module.calendar_monthly .square-content .today {
 	border: 1px solid #cccccc;
 	border-radius: 2px;
 	background-color: #cccccc;
@@ -28,13 +28,13 @@
 	color: #333333;
 }
 
-.square-content div {
+.module.calendar_monthly .square-content div {
 	display: table;
 	width: 100%;
 	height: 100%;
 }
 
-.square-content span {
+.module.calendar_monthly .square-content span {
 	display: table-cell;
 	text-align: center;
 	vertical-align: middle;

--- a/css/themes/custom.css
+++ b/css/themes/custom.css
@@ -2,62 +2,62 @@
  * and some additional colors
  */
 
-#yearDigits {
+.module.calendar_monthly #yearDigits {
 	color: #fff;
 	font-weight: normal;
 } 
 
-#monthName {
+.module.calendar_monthly #monthName {
 	font-weight: normal;
 }
 
-#monthName:after {
+.module.calendar_monthly #monthName:after {
 	content: " •";
 	color: #80ff00;
 	font-weight: bold;
 }
 
-.monthPrev {
+.module.calendar_monthly .monthPrev {
 	color: #333333;
 }
 
-.monthNext {
+.module.calendar_monthly .monthNext {
 	color: #333333;
 }
 
-.square-box {
+.module.calendar_monthly .square-box {
 	position: relative;
 	width: 50%;
 	overflow: hidden;
 	margin: 0px auto;
 }
 
-.square-box:before {
+.module.calendar_monthly .square-box:before {
 	content: "";
 	display: block;
 	padding-top: 20%;
 }
 
-.square-content {
+.module.calendar_monthly .square-content {
 	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
 }
 
-.square-content .today {
+.module.calendar_monthly .square-content .today {
 	border: 1px solid #80ff00;
 	font-weight: normal;
 	color: #80ff00;
 }
 
-.square-content div {
+.module.calendar_monthly .square-content div {
 	display: table;
 	width: 100%;
 	height: 100%;
 }
 
-.square-content span {
+.module.calendar_monthly .square-content span {
 	display: table-cell;
 	text-align: center;
 	vertical-align: middle;

--- a/css/themes/slate.css
+++ b/css/themes/slate.css
@@ -1,76 +1,76 @@
 /* Slate styling, meant for mirrorless displays */
 
-.calendar-header-day {
+.module.calendar_monthly .calendar-header-day {
 	color: #18b165;
 	font-weight: bold;
 	background-color: #2a3139;
 	border-bottom: 1px solid #232833;
 }
 
-.weekRow {
+.module.calendar_monthly .weekRow {
 	background-color: #404854;
 }
 
-#monthName {
+.module.calendar_monthly #monthName {
 	font-weight: normal;
 	color: #8a99af;
 }
 
-#yearDigits {
+.module.calendar_monthly #yearDigits {
 	color: #8a99af;
 	font-weight: normal;
 }
 
-#calendar-th {
+.module.calendar_monthly #calendar-th {
 	border-bottom: 1px solid #181b21;
 	background-color: #242930;
 	padding-top: 5px;
 	font-weight: bold;
 }
-.calendar-day {
+.module.calendar_monthly .calendar-day {
 	color: #88a0b8;
 }
 
-.monthPrev {
+.module.calendar_monthly .monthPrev {
 	color: #677176;
 }
 
-.monthNext {
+.module.calendar_monthly .monthNext {
 	color: #677176;
 }
 
-.square-box {
+.module.calendar_monthly .square-box {
 	position: relative;
 	width: 50%;
 	overflow: hidden;
 	margin: 0px auto;
 }	
 
-.square-box:before {
+.module.calendar_monthly .square-box:before {
 	content: "";
 	display: block;
 	padding-top: 20%;
 }
 
-.square-content {
+.module.calendar_monthly .square-content {
 	top: 0;
 	left: 0;
 	bottom: 0;
 	right: 0;
 }
 
-.square-content .today {
+.module.calendar_monthly .square-content .today {
 	font-weight: bold;
 	color: #ffffff;
 }
 
-.square-content div {
+.module.calendar_monthly .square-content div {
 	display: table;
 	width: 100%;
 	height: 100%;
 }
 
-.square-content span {
+.module.calendar_monthly .square-content span {
 	display: table-cell;
 	text-align: center;
 	vertical-align: middle;


### PR DESCRIPTION
Currently the selectors would also match other modules' contents. Using a more narrow selector makes sure that you don't break the css of other modules.